### PR TITLE
Add threads argument to the call of StreamingQueryDNADatabase.py.

### DIFF
--- a/scripts/select_db.py
+++ b/scripts/select_db.py
@@ -72,7 +72,8 @@ def run_cmash_and_cutoff(args, taxid2info):
 		cmash_out = args.temp_dir + 'cmash_query_results.csv'
 		cmash_proc = subprocess.Popen(['StreamingQueryDNADatabase.py',
 			args.temp_dir + '60mers_intersection_dump.fa', cmash_db_loc,
-			cmash_out, '30-60-10', '-c', '0', '-r', '1000000', '-v',
+			cmash_out, '30-60-10', '-c', '0', '-r', '1000000', 
+			'-t', str(args.threads), '-v',
 			'-f', cmash_filter_loc, '--sensitive']).wait()
 	else:
 		cmash_out = args.cmash_results


### PR DESCRIPTION
Currently the call to StreamingQueryDNADatabase.py doesn't specify the threads argument. This results in CMash's StreamingQueryDNADatabase.py using the default of multiprocessing.cpu_count() which returns the number of CPUs in the system.

This can cause application performance and memory issues on batch systems (e.g. Slurm) which contain hosts with large core counts.